### PR TITLE
Support specifying different kernel for building

### DIFF
--- a/src/kmod/Makefile
+++ b/src/kmod/Makefile
@@ -1,6 +1,8 @@
 obj-m += mimic.o
 
-system_build_dir := /lib/modules/$(shell uname -r)/build
+KERNEL_UNAME ?= $(shell uname -r)
+
+system_build_dir := /lib/modules/$(KERNEL_UNAME)/build
 PWD := $(CURDIR)
 
 # Notes on Debian hack:


### PR DESCRIPTION
By specifying make KERNEL_UNAME=x.x.x-xxx, `mimic` can build on different kernel as specified.