### PR TITLE
Add memory barrier

### DIFF
--- a/bpf/ingress.c
+++ b/bpf/ingress.c
@@ -74,6 +74,7 @@ static inline int read_tcp_options(struct xdp_md* xdp, struct tcphdr* tcp, __u32
   }
 
   for (__u32 i = 0; i < len; i++) {
+    barrier_var(i);
     if (unlikely(i > 80 - 1)) return XDP_DROP;
     switch (opt_buf[i]) {
       case 0:  // end of option list

--- a/docs/building.md
+++ b/docs/building.md
@@ -55,6 +55,7 @@ Then install with:
 ```
 
 Debian < 12 (bullseye, buster or earlier) and Ubuntu < 23.04 (kinetic, jammy or earlier) are not supported due to outdated libbpf 0.x and Linux kernel < 6.1.
+Debian 12 and Ubuntu before 24.10 need to enable Backports repository for the build dependency `dh-sequence-dlopenlibdeps`.
 
 ## Notes on Building Kernel Module
 


### PR DESCRIPTION
With Clang 14 the code is reordered and fails the verifier:

https://github.com/hack3ric/mimic/blob/a8989efb026e85a6e204dfadac137c1a4b741ceb/bpf/ingress.c#L76-L96

Error:

```
...
; if (bpf_skb_load_bytes(skb, pkt_off + offset, packet, copy_len) < 0) cleanup(TC_ACT_SHOT);
1283: (79) r1 = *(u64 *)(r10 -24)     ; R1_w=ctx(off=0,imm=0) R10=fp0 refs=7
1284: (bc) w2 = w9                    ; R2_w=scalar(umax=4294967295,var_off=(0x0; 0xffffffff)) R9_w=scalar
(umax=4294967295,var_off=(0x0; 0xffffffff)) refs=7
1285: (bf) r3 = r0                    ; R0=mem(ref_obj_id=7,off=0,imm=0) R3_w=mem(ref_obj_id=7,off=0,imm=0
) refs=7
1286: (bc) w4 = w8                    ; R4_w=scalar(umin=2,umax=4294967295,var_off=(0x0; 0xffffffff),s32_min=-9920,s32_max=16) R8=scalar(umin=2,umax=4294967295,var_off=(0x0; 0xffffffff),s32_min=-9920,s32_max=16)
refs=7
1287: (85) call bpf_skb_load_bytes#26
R4 unbounded memory access, use 'var &= const' or 'if (var < const)'
processed 3285 insns (limit 1000000) max_states_per_insn 4 total_states 60 peak_states 60 mark_read 54
-- END PROG LOAD LOG --
 Warn libbpf: prog 'egress_handler': failed to load: -13
 Warn libbpf: failed to load object 'mimic_bpf'
 Warn libbpf: failed to load BPF skeleton 'mimic_bpf': -13
Error failed to load BPF program: Permission denied
```

The memory barrier fixes this.

Besides, adding a note for building Debian packages on older distros.