### PR TITLE
Fix BPF verifier failure on Arch Linux (clang 20, kernel 6.15)

### DIFF
--- a/bpf/main.c
+++ b/bpf/main.c
@@ -60,7 +60,7 @@ int store_packet(struct __sk_buff* skb, __u32 pkt_off, struct conn_tuple* key, i
   }
   if (has_remainder) {
     offset = i * SEGMENT_SIZE;
-    __u32 copy_len = data_len - offset;
+    __u32 copy_len = data_len % SEGMENT_SIZE;
     if (copy_len > 0 && copy_len < SEGMENT_SIZE) {
       bpf_gt0_hack1(copy_len);
       packet = bpf_dynptr_data(&ptr, sizeof(*item) + offset, SEGMENT_SIZE);


### PR DESCRIPTION
This commit resolves a BPF verifier error encountered on Arch Linux using clang version 20.1.8 and kernel 6.15.7-2-cachyos. The verifier complained about a possible zero-sized read due to copy_len calculation in the last segment of packet copying logic. Switched to using `data_len % SEGMENT_SIZE` instead of `data_len - offset` to ensure the value is always within [1, SEGMENT_SIZE-1], making the verifier happy across different toolchains.