### PR TITLE
Workaround fail after wake from suspend by restart

### DIFF
--- a/install/mimic@.service.in
+++ b/install/mimic@.service.in
@@ -6,7 +6,7 @@ Requires = modprobe@mimic.service
 [Service]
 Type = notify
 ExecStart = @@MIMIC_EXEC@@ run %i -F @@MIMIC_CONFIG_PATH@@/%i.conf
-Restart = on-abnormal
+Restart = on-failure
 
 User = mimic
 RuntimeDirectory = @@MIMIC_RUNTIME_DIR@@


### PR DESCRIPTION
Issue Description:

After system wake from suspend, mimic systemd service will fail.

How to reproduce:

On Arch Linux, with NetworkManager or systemd-networkd. Run `sudo systemctl suspend` to suspend the system, then wake it. `systemctl status mimic@ens18` (replace ens18 with your network interface name) will show "Active: failed (Result: exit-code)".  `journalctl -b -u mimic@ens18` will output sth. like:

    Aug 07 15:29:25 xyzpp mimic[27493]: Error error waiting for epoll: Interrupted system call
    Aug 07 15:29:25 xyzpp mimic[27493]: Error failed to send: Network is unreachable
    Aug 07 15:29:25 xyzpp systemd[1]: mimic@wlan0.service: Main process exited, code=exited, status=4/NOPERMISSION
    Aug 07 15:29:25 xyzpp systemd[1]: mimic@wlan0.service: Failed with result 'exit-code'.

Sometimes you need to use `journalctl -b` instead to show more error messages.

The unit failed after system wake from suspend. I think the error of "Error error waiting for epoll: Interrupted system call" maybe is more related because sometimes "Error failed to send: Network is unreachable" error is not shown but unit still failed. "code=exited, status=4/NOPERMISSION" is what caused the systemd service to fail.

Fix and reasons:

My workaround is to just automatically restart mimic systemd unit if it failed after wake from suspend. By reading `man systemd.service`, I learned that on-failure is just on-abnormal but also restart with unclean exit code. Thus, I choose `Restart = on-failure`. I tested on Arch Linux with NetworkManager or systemd-networkd and it seems fixed the issue. At least I don't need to manually restart mimic after it failed after wake from suspend.

`man systemd-system.conf` shows DefaultStartLimitIntervalSec= defaults to 10s, and DefaultStartLimitBurst= defaults to 5. So I think we don't need to worry about it restart too much. Every time it failed after wake from suspend, it only restart once.

However, this fix is more like a workaround. Maybe a more proper way to fix the issue is by editing some other codes.