### PR TITLE
Fix Arch Linux coredump

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -24,7 +24,7 @@ static int notify_systemd(const char* msg) {
   struct sockaddr_un addr = {.sun_family = AF_UNIX};
   size_t path_len = strlen(socket_path);
   if (path_len >= sizeof(addr.sun_path)) return -E2BIG;
-  memcpy(addr.sun_path, socket_path, sizeof(addr.sun_path));
+  memcpy(addr.sun_path, socket_path, path_len+1);
   if (socket_path[0] == '@') addr.sun_path[0] = 0;
 
   int sk raii(closep) = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);


### PR DESCRIPTION
# I don't completely understand the code, please take your time to consider my patch correct or wrong, I maybe completely wrong. I don't have time to dig deeper for now and sorry for my bad writing due to time constraint.

# related: https://aur.archlinux.org/pkgbase/mimic-bpf-git#comment-1040506

environment: arch linux with aur/mimic-bpf-git pkg

mimic failed and coredump after me upgrade all my packages to latest on 2025-09-21T6:36Z, not sure what's the cause, maybe due to latest linux kernel version 6.16.8, but I tried switch to linux-lts and linux-lts-headers but mimic still fail and coredump.

mimic works fine on another computer without upgrade since 2025-09-14T09: 20Z, that linux kernel version is 6.16.7.

I'm trying to debugging it, with optimization on, the coredump is like:

    Stack trace of thread 17630:
    #0  0x00005596d32d8b26 memcpy (/usr/bin/mimic + 0x4b26)
    #1  0x00007f9f75427675 n/a (libc.so.6 + 0x27675)
    #2  0x00007f9f75427729 __libc_start_main (libc.so.6 + 0x27729)
    #3  0x00005596d32da2c5 _start (/usr/bin/mimic + 0x62c5)
    ELF object binary architecture: AMD x86-64

With optimization on, the gdb backtrace of the coredump is like:

    (gdb) bt
    #0  0x00005596d32d8b26 in memcpy (__dest=<optimized out>, __src=<optimized out>, __len=<optimized out>,
	__dest=<optimized out>, __src=<optimized out>, __len=<optimized out>) at /usr/include/bits/string_fortified.h:29
    #1  notify_systemd (msg=0x5596d32df7ef "READY=1") at src/notify.c:27
    #2  notify_ready () at src/notify.c:42
    #3  run_bpf (args=0x7ffcc4f28f68, lock_fd=4, ifname=0x7ffcc4f2be3b "ens18", ifindex=2) at src/run.c:637
    #4  subcmd_run (args=0x7ffcc4f28f68) at src/run.c:807
    #5  main (argc=<optimized out>, argv=<optimized out>) at src/main.c:20

With optimization off, the coredump is:

     Stack trace of thread 415:
     #0  0x00005642df3f2eac notify_systemd (/usr/bin/mimic + 0x6eac)
     #1  0x00005642df3f3078 notify_ready (/usr/bin/mimic + 0x7078)
     #2  0x00005642df3f71b3 run_bpf (/usr/bin/mimic + 0xb1b3)
     #3  0x00005642df3f858d subcmd_run (/usr/bin/mimic + 0xc58d)
     #4  0x00005642df3f28cf main (/usr/bin/mimic + 0x68cf)
     #5  0x00007f6730827675 n/a (libc.so.6 + 0x27675)
     #6  0x00007f6730827729 __libc_start_main (libc.so.6 + 0x27729)
     #7  0x00005642df3ef045 _start (/usr/bin/mimic + 0x3045)
     ELF object binary architecture: AMD x86-64

With optimization off, the backtrace is:

    (gdb) bt
    #0  0x0000563638828eac in notify_systemd (msg=0x563638830a7e "READY=1") at src/notify.c:27
    #1  0x0000563638829078 in notify_ready () at src/notify.c:42
    #2  0x000056363882d1b3 in run_bpf (args=0x7ffd9c33c338, lock_fd=4, ifname=0x7ffd9c33de3e "ens18", ifindex=2) at src/run.c:637
    #3  0x000056363882e58d in subcmd_run (args=0x7ffd9c33c338) at src/run.c:807
    #4  0x00005636388288cf in main (argc=5, argv=0x7ffd9c33d918) at src/main.c:20

So maybe it seems like related to new systemd version? I'm not sure.

By reading the backtrace, it seems related to memcpy() function in src/notify.c `memcpy(addr.sun_path, socket_path, sizeof(addr.sun_path));
`, I changed `sizeof(addr.sun_path)` to `path_len+1` and the issue somehow fixed. I have no idea why, I just guessed it, maybe it is completely wrong in someway, but it works. I guess the reason is src/notify.c memcpy is trying to copy from `socket_path` to `addr.sun_path`, and I tried to test it with some fprintf and it shows that path_len is strlen(socket_path) which equals to 19, and sizeof(addr.sun_path) equals to 108, so the issue maybe due to memcpy maybe trying to copy 108 size from socket_path to addr.sun_path, but socket_path only has size 19, which causes coredump. So if we change `sizeof(addr.sun_path)` to `path_len` in memcpy function with this patch, memcpy will only trying to copy size of path_len which is strlen(socket_path) which is 19 from socket_path to addr.sun_path, this will not exceed size of socket_path which will not coredump. Another thing to note is path_len is a variable assigned from strlen() and strlen() does not count '\0' character at the end so we need to consider that and add 1, so instead of path_len, we need to use path_len+1 in memcpy(), however, I'm not so sure about if this is correct, maybe I'm overthinking, my test shows with or without +1 both works.

The fprintf patch I used to test to know size of things are (note this test is before I realized that strlen does not count '\0' and I did not use path_len+1, but I think with or without should not affect size outputs. One thing I'm not sure is if without changing memcpy, does the size outputs the same or not, I did not have time to test this tho):
```diff
diff --git a/src/notify.c b/src/notify.c
index bd5dc9a..2c851ce 100644
--- a/src/notify.c
+++ b/src/notify.c
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #include "common/defs.h"
 #include "main.h"
@@ -24,7 +25,9 @@ static int notify_systemd(const char* msg) {
   struct sockaddr_un addr = {.sun_family = AF_UNIX};
   size_t path_len = strlen(socket_path);
   if (path_len >= sizeof(addr.sun_path)) return -E2BIG;
-  memcpy(addr.sun_path, socket_path, sizeof(addr.sun_path));
+  fprintf(stderr,"path_len=strlen(socket_path): %lu",path_len);
+  fprintf(stderr,"sizeof(addr.sun_path): %lu",sizeof(addr.sun_path));
+  memcpy(addr.sun_path, socket_path, path_len);
   if (socket_path[0] == '@') addr.sun_path[0] = 0;
 
   int sk raii(closep) = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
```

On my machine, it outpus `Sep 21 08:55:24 xyzba mimic[416]: path_len=strlen(socket_path): 19sizeof(addr.sun_path): 108 Info Mimic successfully deployed on ens18` in systemd log.

# Also note github messed up my commit message and shows coredump's outputs like `#1` as `hack3ric#1` which are wrong!