### PR TITLE
fix(config): serialize PADDING_RANDOM as 'random' in lock file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -366,7 +366,10 @@ int write_lock_file(int fd, const struct lock_content* c) {
   try(dprintf(fd, "handshake=%d:%d\n", c->settings.h.i, c->settings.h.r));
   try(dprintf(fd, "keepalive=%d:%d:%d:%d\n", c->settings.k.t, c->settings.k.i, c->settings.k.r,
               c->settings.k.s));
-  try(dprintf(fd, "padding=%d\n", c->settings.padding));
+  if (c->settings.padding == PADDING_RANDOM)
+    try(dprintf(fd, "padding=random\n"));
+  else
+    try(dprintf(fd, "padding=%d\n", c->settings.padding));
   try(dprintf(fd, "max_window=%d\n", c->settings.max_window));
   return 0;
 }


### PR DESCRIPTION
write_lock_file emitted the raw sentinel value (-127), which parse_padding rejects on read-back, causing 'mimic show' to fail with 'integer out of range' when padding is configured to random.