### PR TITLE
feat: add anti_gro setting to defeat TCP-GRO coalescing

### DIFF
--- a/bpf/egress.c
+++ b/bpf/egress.c
@@ -50,10 +50,12 @@ static inline int mangle_data(struct __sk_buff* skb, __u16 offset, __be32* csum_
   return TC_ACT_OK;
 }
 
-static inline void update_tcp_header(struct tcphdr* tcp, __u16 tcp_payload_len, __u32 seq,
-                                     __u32 ack_seq, __u16 window) {
+static __always_inline void update_tcp_header(struct tcphdr* tcp, __u16 tcp_payload_len, __u32 seq,
+                                              __u32 ack_seq, __u16 window, __u32 ack_jitter) {
   tcp->seq = htonl(seq);
-  tcp->ack_seq = htonl(ack_seq);
+  // ack_jitter defeats Linux TCP-GRO coalescing: tcp_gro_receive flushes on
+  // any wire-ack_seq mismatch between consecutive same-flow packets.
+  tcp->ack_seq = htonl(ack_seq + ack_jitter);
   tcp_flag_word(tcp) = 0;
   tcp->doff = 5;
   tcp->window = htons(window);
@@ -230,7 +232,8 @@ int egress_handler(struct __sk_buff* skb) {
   __be32 csum_diff = 0;
   try_tc(mangle_data(skb, ip_end + sizeof(*udp), &csum_diff, padding));
   decl_shot(struct tcphdr, tcp, ip_end, skb);
-  update_tcp_header(tcp, payload_len, seq, ack_seq, window);
+  __u32 ack_jitter = conn->settings.anti_gro ? bpf_get_prandom_u32() : 0;
+  update_tcp_header(tcp, payload_len, seq, ack_seq, window, ack_jitter);
 
   __u32 csum_off = ip_end + offsetof(struct tcphdr, check);
   redecl_shot(struct tcphdr, tcp, ip_end, skb);

--- a/common/defs.h
+++ b/common/defs.h
@@ -284,8 +284,9 @@ struct filter_settings {
       } keepalive, k; };
       __s16 padding;
       __s16 max_window;
+      __s16 anti_gro;
     };
-    __s16 array[8];
+    __s16 array[9];
   };
 };
 // clang-format on
@@ -304,10 +305,11 @@ static const struct filter_settings DEFAULT_SETTINGS = {
   .keepalive.array = {180, 10, 3, 600},
   .padding = 0,
   .max_window = false,
+  .anti_gro = false,
 };
 
 static const struct filter_settings FALLBACK_SETTINGS = {
-  .array = {-1, -1, -1, -1, -1, -1, -1, -1},
+  .array = {-1, -1, -1, -1, -1, -1, -1, -1, -1},
 };
 
 static inline void filter_settings_apply(struct filter_settings* local,
@@ -394,8 +396,10 @@ static __always_inline __u32 conn_cooldown_display(struct connection* conn) {
 }
 
 static __always_inline __u32 conn_padding(struct connection* conn, __u32 seq, __u32 ack_seq) {
-  return conn->settings.padding == PADDING_RANDOM ? (seq + ack_seq) % 11
-                                                  : (__u32)conn->settings.padding;
+  if (conn->settings.padding != PADDING_RANDOM) return (__u32)conn->settings.padding;
+  // When anti_gro is on, the wire ack_seq is jittered per packet and isn't recoverable
+  // by the receiver, so drop it from the entropy mix to keep padding symmetric.
+  return (seq + (conn->settings.anti_gro ? 0 : ack_seq)) % 11;
 }
 
 static __always_inline __be32 conn_max_window(struct connection* conn) {

--- a/src/config.c
+++ b/src/config.c
@@ -170,6 +170,8 @@ static int parse_setting(const char* k, char* v, struct filter_settings* setting
     try(parse_padding(v, &settings->padding));
   else if (strcmp("max_window", k) == 0)
     try(parse_bool(v, &settings->max_window));
+  else if (strcmp("anti_gro", k) == 0)
+    try(parse_bool(v, &settings->anti_gro));
   else
     return 0;
   return 1;
@@ -368,5 +370,6 @@ int write_lock_file(int fd, const struct lock_content* c) {
               c->settings.k.s));
   try(dprintf(fd, "padding=%d\n", c->settings.padding));
   try(dprintf(fd, "max_window=%d\n", c->settings.max_window));
+  try(dprintf(fd, "anti_gro=%d\n", c->settings.anti_gro));
   return 0;
 }

--- a/src/show.c
+++ b/src/show.c
@@ -83,6 +83,7 @@ int show_overview(int ifindex, enum link_type link_type, int whitelist_fd,
   else if (gs->padding)
     fprintf(out, _(", padding %d"), gs->padding);
   if (gs->max_window) fprintf(out, _(", max window"));
+  if (gs->anti_gro) fprintf(out, _(", anti gro"));
   fprintf(out, "\n");
 
   char buf[FILTER_FMT_MAX_LEN];
@@ -120,6 +121,8 @@ int show_overview(int ifindex, enum link_type link_type, int whitelist_fd,
     }
     if (a->max_window != b->max_window)
       fprintf(out, _(",max_window=%s"), info.settings.max_window ? "true" : "false");
+    if (a->anti_gro != b->anti_gro)
+      fprintf(out, _(",anti_gro=%s"), info.settings.anti_gro ? "true" : "false");
     if (strlen(info.host) != 0) fprintf(out, _(" %s(resolved from %s)"), RESET GRAY, info.host);
     fprintf(out, RESET "\n");
   }


### PR DESCRIPTION
Linux 6.18's PPPoE GRO offload (and any TCP-aware GRO path) coalesces a stream of mimic-produced fake-TCP packets into a single superframe, since mimic emits a constant wire ack_seq across a data burst. The receiver's XDP ingress then demangles the superframe as one packet, producing garbage that WireGuard drops -- collapsing ingress throughput.

New per-filter setting `anti_gro` (default off) makes egress add a per-packet random jitter to the wire ack_seq, which trips the flush check at net/ipv4/tcp_offload.c:337 (flush |= th->ack_seq ^ th2->ack_seq) and prevents coalescing in both the normal merge and fraglist paths. The padding entropy in conn_padding is adjusted to drop ack_seq when anti_gro is on, keeping receiver-side padding computation symmetric.

Both peers must enable the setting; default off preserves compatibility with prior mimic versions.